### PR TITLE
Handle headers that are defined more than once

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Signs and validates HTTP requests based on a shared-secret HMAC signature.
 
+Developed in parallel with the following packages for other languages:
+- Node.js: [hmac-authentication](https://www.npmjs.com/package/hmac-authentication)
+- Ruby: [hmac_authentication](https://rubygems.org/gems/hmac_authentication)
+
 ## Installation
 
 ```go

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -29,9 +29,11 @@ func StringToSign(req *http.Request, headers []string) string {
 	buffer.WriteString(req.Method)
 	buffer.WriteString("\n")
 
-	for _, header := range headers {
+	for headerNum, header := range headers {
+		tag := strconv.Itoa(headerNum)
 		values := req.Header[header]
 		for _, value := range values {
+			buffer.WriteString(tag)
 			buffer.WriteString(value)
 			buffer.WriteString("\n")
 		}

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -66,7 +66,11 @@ func NewHmacAuth(hash crypto.Hash, key []byte, header string,
 		}
 		panic("hmacauth: hash algorithm " + name + " is unavailable")
 	}
-	return &HmacAuth{hash, key, header, headers}
+	canonicalHeaders := make([]string, len(headers))
+	for i, h := range headers {
+		canonicalHeaders[i] = http.CanonicalHeaderKey(h)
+	}
+	return &HmacAuth{hash, key, header, canonicalHeaders}
 }
 
 func (auth *HmacAuth) StringToSign(req *http.Request) string {

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -11,17 +11,29 @@ import (
 	"strings"
 )
 
+// HmacAuth signs outbound requests and authenticates inbound requests.
 type HmacAuth interface {
+	// Produces the string that will be prefixed to the request body and
+	// used to generate the signature.
 	StringToSign(req *http.Request) string
+
+	// Adds a signature header to the request.
 	SignRequest(req *http.Request)
+
+	// Generates a signature for the request.
 	RequestSignature(req *http.Request) string
+
+	// Retrieves the signature included in the request header.
 	SignatureFromHeader(req *http.Request) string
+
+	// Authenticates the request, returning the result code, the signature
+	// from the header, and the locally-computed signature.
 	ValidateRequest(request *http.Request) (
 		result ValidationResult,
 		headerSignature, computedSignature string)
 }
 
-var supportedAlgorithms map[string]crypto.Hash = map[string]crypto.Hash{
+var supportedAlgorithms = map[string]crypto.Hash{
 	"md4":       crypto.MD4,
 	"md5":       crypto.MD5,
 	"sha1":      crypto.SHA1,
@@ -50,6 +62,8 @@ func init() {
 	}
 }
 
+// DigestNameToCryptoHash returns the crypto.Hash value corresponding to the
+// algorithm name, or an error if the algorithm is not supported.
 func DigestNameToCryptoHash(name string) (result crypto.Hash, err error) {
 	var supported bool
 	if result, supported = supportedAlgorithms[name]; !supported {
@@ -59,6 +73,8 @@ func DigestNameToCryptoHash(name string) (result crypto.Hash, err error) {
 	return
 }
 
+// CryptoHashToDigestName returns the algorithm name corresponding to the
+// crypto.Hash ID, or an error if the algorithm is not supported.
 func CryptoHashToDigestName(id crypto.Hash) (result string, err error) {
 	var supported bool
 	if result, supported = algorithmName[id]; !supported {
@@ -75,6 +91,8 @@ type hmacAuth struct {
 	headers []string
 }
 
+// NewHmacAuth returns an HmacAuth object that can be used to sign or
+// authenticate HTTP requests based on the supplied parameters.
 func NewHmacAuth(hash crypto.Hash, key []byte, header string,
 	headers []string) HmacAuth {
 	if hash.Available() == false {
@@ -94,46 +112,31 @@ func NewHmacAuth(hash crypto.Hash, key []byte, header string,
 
 func (auth *hmacAuth) StringToSign(req *http.Request) string {
 	var buffer bytes.Buffer
-	buffer.WriteString(req.Method)
-	buffer.WriteString("\n")
+	_, _ = buffer.WriteString(req.Method)
+	_, _ = buffer.WriteString("\n")
 
 	for _, header := range auth.headers {
 		values := req.Header[header]
 		lastIndex := len(values) - 1
 		for i, value := range values {
-			buffer.WriteString(value)
+			_, _ = buffer.WriteString(value)
 			if i != lastIndex {
-				buffer.WriteString(",")
+				_, _ = buffer.WriteString(",")
 			}
 		}
-		buffer.WriteString("\n")
+		_, _ = buffer.WriteString("\n")
 	}
-	buffer.WriteString(req.URL.Path)
+	_, _ = buffer.WriteString(req.URL.Path)
 	if req.URL.RawQuery != "" {
-		buffer.WriteString("?")
-		buffer.WriteString(req.URL.RawQuery)
+		_, _ = buffer.WriteString("?")
+		_, _ = buffer.WriteString(req.URL.RawQuery)
 	}
 	if req.URL.Fragment != "" {
-		buffer.WriteString("#")
-		buffer.WriteString(req.URL.Fragment)
+		_, _ = buffer.WriteString("#")
+		_, _ = buffer.WriteString(req.URL.Fragment)
 	}
-	buffer.WriteString("\n")
+	_, _ = buffer.WriteString("\n")
 	return buffer.String()
-}
-
-type unsupportedAlgorithm struct {
-	algorithm string
-}
-
-func (e unsupportedAlgorithm) Error() string {
-	return "unsupported request signature algorithm: " + e.algorithm
-}
-
-func HashAlgorithm(algorithm string) (result crypto.Hash, err error) {
-	if result = supportedAlgorithms[algorithm]; result == crypto.Hash(0) {
-		err = unsupportedAlgorithm{algorithm}
-	}
-	return
 }
 
 func (auth *hmacAuth) SignRequest(req *http.Request) {
@@ -147,12 +150,12 @@ func (auth *hmacAuth) RequestSignature(req *http.Request) string {
 func requestSignature(auth *hmacAuth, req *http.Request,
 	hashAlgorithm crypto.Hash) string {
 	h := hmac.New(hashAlgorithm.New, auth.key)
-	h.Write([]byte(auth.StringToSign(req)))
+	_, _ = h.Write([]byte(auth.StringToSign(req)))
 
 	if req.ContentLength != -1 && req.Body != nil {
 		buf := make([]byte, req.ContentLength, req.ContentLength)
-		req.Body.Read(buf)
-		h.Write(buf)
+		_, _ = req.Body.Read(buf)
+		_, _ = h.Write(buf)
 	}
 
 	var sig []byte
@@ -165,23 +168,38 @@ func (auth *hmacAuth) SignatureFromHeader(req *http.Request) string {
 	return req.Header.Get(auth.header)
 }
 
+// ValidationResult is a code used to identify the outcome of
+// HmacAuth.ValidateRequest().
 type ValidationResult int
 
 const (
-	NO_SIGNATURE ValidationResult = iota
-	INVALID_FORMAT
-	UNSUPPORTED_ALGORITHM
-	MATCH
-	MISMATCH
+	// ResultNoSignature - the incoming result did not have a signature
+	// header.
+	ResultNoSignature ValidationResult = iota
+
+	// ResultInvalidFormat - the signature header was not parseable.
+	ResultInvalidFormat
+
+	// ResultUnsupportedAlgorithm - the signature header specified an
+	// unsupported algorithm.
+	ResultUnsupportedAlgorithm
+
+	// ResultMatch - the signature from the request header matched the
+	// locally-computed signature.
+	ResultMatch
+
+	// ResultMismatch - the signature from the request header did not match
+	// the locally-computed signature.
+	ResultMismatch
 )
 
-var validationResultStrings []string = []string{
+var validationResultStrings = []string{
 	"",
-	"NO_SIGNATURE",
-	"INVALID_FORMAT",
-	"UNSUPPORTED_ALGORITHM",
-	"MATCH",
-	"MISMATCH",
+	"ResultNoSignature",
+	"ResultInvalidFormat",
+	"ResultUnsupportedAlgorithm",
+	"ResultMatch",
+	"ResultMismatch",
 }
 
 func (result ValidationResult) String() string {
@@ -192,27 +210,27 @@ func (auth *hmacAuth) ValidateRequest(request *http.Request) (
 	result ValidationResult, headerSignature, computedSignature string) {
 	headerSignature = auth.SignatureFromHeader(request)
 	if headerSignature == "" {
-		result = NO_SIGNATURE
+		result = ResultNoSignature
 		return
 	}
 
 	components := strings.Split(headerSignature, " ")
 	if len(components) != 2 {
-		result = INVALID_FORMAT
+		result = ResultInvalidFormat
 		return
 	}
 
-	algorithm, err := HashAlgorithm(components[0])
+	algorithm, err := DigestNameToCryptoHash(components[0])
 	if err != nil {
-		result = UNSUPPORTED_ALGORITHM
+		result = ResultUnsupportedAlgorithm
 		return
 	}
 
 	computedSignature = requestSignature(auth, request, algorithm)
 	if hmac.Equal([]byte(headerSignature), []byte(computedSignature)) {
-		result = MATCH
+		result = ResultMatch
 	} else {
-		result = MISMATCH
+		result = ResultMismatch
 	}
 	return
 }

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -29,17 +29,16 @@ func StringToSign(req *http.Request, headers []string) string {
 	buffer.WriteString(req.Method)
 	buffer.WriteString("\n")
 
-	for headerNum, header := range headers {
-		tag := strconv.Itoa(headerNum)
+	for _, header := range headers {
 		values := req.Header[header]
-		for _, value := range values {
-			buffer.WriteString(tag)
+		lastIndex := len(values) - 1
+		for i, value := range values {
 			buffer.WriteString(value)
-			buffer.WriteString("\n")
+			if i != lastIndex {
+				buffer.WriteString(",")
+			}
 		}
-		if len(values) == 0 {
-			buffer.WriteString("\n")
-		}
+		buffer.WriteString("\n")
 	}
 	buffer.WriteString(req.URL.Path)
 	if req.URL.RawQuery != "" {

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -98,9 +98,10 @@ func (result ValidationResult) String() string {
 	return strconv.Itoa(int(result))
 }
 
-func ValidateRequest(request *http.Request, headers []string, key string) (
+func ValidateRequest(request *http.Request, signatureHeader string,
+	headers []string, key string) (
 	result ValidationResult, headerSignature, computedSignature string) {
-	headerSignature = request.Header.Get("Gap-Signature")
+	headerSignature = request.Header.Get(signatureHeader)
 	if headerSignature == "" {
 		result = NO_SIGNATURE
 		return

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -15,12 +15,23 @@ var algorithmName map[crypto.Hash]string
 
 func init() {
 	supportedAlgorithms = map[string]crypto.Hash{
-		"sha1": crypto.SHA1,
+		"md4":       crypto.MD4,
+		"md5":       crypto.MD5,
+		"sha1":      crypto.SHA1,
+		"sha224":    crypto.SHA224,
+		"sha256":    crypto.SHA256,
+		"sha384":    crypto.SHA384,
+		"sha512":    crypto.SHA512,
+		"ripemd160": crypto.RIPEMD160,
 	}
 
 	algorithmName = make(map[crypto.Hash]string)
 	for name, algorithm := range supportedAlgorithms {
-		algorithmName[algorithm] = name
+		if algorithm.Available() {
+			algorithmName[algorithm] = name
+		} else {
+			delete(supportedAlgorithms, name)
+		}
 	}
 }
 
@@ -33,8 +44,9 @@ type HmacAuth struct {
 
 func NewHmacAuth(hash crypto.Hash, key []byte, header string,
 	headers []string) *HmacAuth {
-	if algorithmName[hash] == "" {
-		panic("unsupported hash algorithm: " + strconv.Itoa(int(hash)))
+	if hash.Available() == false {
+		panic("hmacauth: hash algorithm #" + strconv.Itoa(int(hash)) +
+			" is unavailable")
 	}
 	return &HmacAuth{hash, key, header, headers}
 }

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -41,7 +41,15 @@ func StringToSign(req *http.Request, headers []string) string {
 			buffer.WriteString("\n")
 		}
 	}
-	buffer.WriteString(req.URL.String())
+	buffer.WriteString(req.URL.Path)
+	if req.URL.RawQuery != "" {
+		buffer.WriteString("?")
+		buffer.WriteString(req.URL.RawQuery)
+	}
+	if req.URL.Fragment != "" {
+		buffer.WriteString("#")
+		buffer.WriteString(req.URL.Fragment)
+	}
 	return buffer.String()
 }
 

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -10,21 +10,20 @@ import (
 	"strings"
 )
 
-var supportedAlgorithms map[string]crypto.Hash
+var supportedAlgorithms map[string]crypto.Hash = map[string]crypto.Hash{
+	"md4":       crypto.MD4,
+	"md5":       crypto.MD5,
+	"sha1":      crypto.SHA1,
+	"sha224":    crypto.SHA224,
+	"sha256":    crypto.SHA256,
+	"sha384":    crypto.SHA384,
+	"sha512":    crypto.SHA512,
+	"ripemd160": crypto.RIPEMD160,
+}
+
 var algorithmName map[crypto.Hash]string
 
 func init() {
-	supportedAlgorithms = map[string]crypto.Hash{
-		"md4":       crypto.MD4,
-		"md5":       crypto.MD5,
-		"sha1":      crypto.SHA1,
-		"sha224":    crypto.SHA224,
-		"sha256":    crypto.SHA256,
-		"sha384":    crypto.SHA384,
-		"sha512":    crypto.SHA512,
-		"ripemd160": crypto.RIPEMD160,
-	}
-
 	algorithmName = make(map[crypto.Hash]string)
 	for name, algorithm := range supportedAlgorithms {
 		if algorithm.Available() {
@@ -133,8 +132,17 @@ const (
 	MISMATCH
 )
 
+var validationResultStrings []string = []string{
+	"",
+	"NO_SIGNATURE",
+	"INVALID_FORMAT",
+	"UNSUPPORTED_ALGORITHM",
+	"MATCH",
+	"MISMATCH",
+}
+
 func (result ValidationResult) String() string {
-	return strconv.Itoa(int(result))
+	return validationResultStrings[result]
 }
 
 func (auth *HmacAuth) ValidateRequest(request *http.Request) (

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"crypto/hmac"
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -31,6 +32,22 @@ func init() {
 			delete(supportedAlgorithms, name)
 		}
 	}
+}
+
+func DigestNameToCryptoHash(name string) (result crypto.Hash, err error) {
+	if result = supportedAlgorithms[name]; result == crypto.Hash(0) {
+		err = errors.New("hmacauth: hash algorithm not supported: " +
+			name)
+	}
+	return
+}
+
+func CryptoHashToDigestName(id crypto.Hash) (result string, err error) {
+	if result = algorithmName[id]; result == "" {
+		err = errors.New("hmacauth: unsupported crypto.Hash #" +
+			strconv.Itoa(int(id)))
+	}
+	return
 }
 
 type HmacAuth struct {

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -98,6 +98,7 @@ func (auth *HmacAuth) StringToSign(req *http.Request) string {
 		buffer.WriteString("#")
 		buffer.WriteString(req.URL.Fragment)
 	}
+	buffer.WriteString("\n")
 	return buffer.String()
 }
 

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -26,9 +26,8 @@ var algorithmName map[crypto.Hash]string
 func init() {
 	algorithmName = make(map[crypto.Hash]string)
 	for name, algorithm := range supportedAlgorithms {
-		if algorithm.Available() {
-			algorithmName[algorithm] = name
-		} else {
+		algorithmName[algorithm] = name
+		if algorithm.Available() == false {
 			delete(supportedAlgorithms, name)
 		}
 	}
@@ -44,8 +43,11 @@ type HmacAuth struct {
 func NewHmacAuth(hash crypto.Hash, key []byte, header string,
 	headers []string) *HmacAuth {
 	if hash.Available() == false {
-		panic("hmacauth: hash algorithm #" + strconv.Itoa(int(hash)) +
-			" is unavailable")
+		var name string
+		if name = algorithmName[hash]; name == "" {
+			name = "#" + strconv.Itoa(int(hash))
+		}
+		panic("hmacauth: hash algorithm " + name + " is unavailable")
 	}
 	return &HmacAuth{hash, key, header, headers}
 }

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -29,9 +29,15 @@ func StringToSign(req *http.Request, headers []string) string {
 	buffer.WriteString(req.Method)
 	buffer.WriteString("\n")
 
-	for i := 0; i != len(headers); i++ {
-		buffer.WriteString(req.Header.Get(headers[i]))
-		buffer.WriteString("\n")
+	for _, header := range headers {
+		values := req.Header[header]
+		for _, value := range values {
+			buffer.WriteString(value)
+			buffer.WriteString("\n")
+		}
+		if len(values) == 0 {
+			buffer.WriteString("\n")
+		}
 	}
 	buffer.WriteString(req.URL.String())
 	return buffer.String()

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -82,7 +82,7 @@ func RequestSignature(req *http.Request, hashAlgorithm crypto.Hash,
 	var sig []byte
 	sig = h.Sum(sig)
 	return algorithmName[hashAlgorithm] + " " +
-		base64.URLEncoding.EncodeToString(sig)
+		base64.StdEncoding.EncodeToString(sig)
 }
 
 type ValidationResult int

--- a/hmacauth_test.go
+++ b/hmacauth_test.go
@@ -143,6 +143,34 @@ func TestRequestSignatureGetWithQuery(t *testing.T) {
 		"sha1 vmli4diHuoO8zY6_9aXmA_yli_o=")
 }
 
+func TestRequestSignatureGetWithFullUrl(t *testing.T) {
+	req := newTestRequest(
+		"GET http://localhost/foo/bar?baz=quux#xyzzy HTTP/1.1",
+		"Date: 2015-09-29",
+		"Cookie: foo; bar; baz=quux",
+		"Gap-Auth: mbland",
+		"",
+		"",
+	)
+
+	assert.Equal(t, StringToSign(req, HEADERS), strings.Join([]string{
+		"GET",
+		"",
+		"",
+		"",
+		"32015-09-29",
+		"",
+		"",
+		"",
+		"",
+		"8foo; bar; baz=quux",
+		"9mbland",
+		"/foo/bar?baz=quux#xyzzy",
+	}, "\n"))
+	assert.Equal(t, RequestSignature(req, crypto.SHA1, HEADERS, "foobar"),
+		"sha1 q5cfavzhqjXieJPAH_fxZHAH3eE=")
+}
+
 func TestRequestSignatureGetWithMultipleHeadersWithTheSameName(t *testing.T) {
 	// Just using "Cookie:" out of convenience.
 	req := newTestRequest(

--- a/hmacauth_test.go
+++ b/hmacauth_test.go
@@ -35,6 +35,8 @@ func TestSupportedHashAlgorithm(t *testing.T) {
 func TestUnsupportedHashAlgorithm(t *testing.T) {
 	algorithm, err := HashAlgorithm("unsupported")
 	assert.NotEqual(t, err, nil)
+	assert.Equal(t, err.Error(),
+		"unsupported request signature algorithm: unsupported")
 	assert.Equal(t, algorithm, crypto.Hash(0))
 	assert.Equal(t, algorithm.Available(), false)
 }

--- a/hmacauth_test.go
+++ b/hmacauth_test.go
@@ -68,20 +68,20 @@ func TestRequestSignaturePost(t *testing.T) {
 	)
 	assert.Equal(t, StringToSign(req, HEADERS), strings.Join([]string{
 		"POST",
-		"0" + strconv.Itoa(len(body)),
-		"1deadbeef",
-		"2application/json",
-		"32015-09-28",
-		"4trust me",
-		"5mbland",
-		"6mbland@acm.org",
-		"7feedbead",
-		"8foo; bar; baz=quux",
-		"9mbland",
+		strconv.Itoa(len(body)),
+		"deadbeef",
+		"application/json",
+		"2015-09-28",
+		"trust me",
+		"mbland",
+		"mbland@acm.org",
+		"feedbead",
+		"foo; bar; baz=quux",
+		"mbland",
 		"/foo/bar",
 	}, "\n"))
 	assert.Equal(t, RequestSignature(req, crypto.SHA1, HEADERS, "foobar"),
-		"sha1 Z7pb9nRlDgdrWgEG+onLubac+0w=")
+		"sha1 722UbRYfC6MnjtIxqEJMDPrW2mk=")
 }
 
 func newGetRequest() *http.Request {
@@ -93,54 +93,6 @@ func newGetRequest() *http.Request {
 		"",
 		"",
 	)
-}
-
-func TestRequestSignatureGet(t *testing.T) {
-	req := newGetRequest()
-	assert.Equal(t, StringToSign(req, HEADERS), strings.Join([]string{
-		"GET",
-		"",
-		"",
-		"",
-		"32015-09-29",
-		"",
-		"",
-		"",
-		"",
-		"8foo; bar; baz=quux",
-		"9mbland",
-		"/foo/bar",
-	}, "\n"))
-	assert.Equal(t, RequestSignature(req, crypto.SHA1, HEADERS, "foobar"),
-		"sha1 pehRvdQcu0CxCIN9Ky+a5jasYYw=")
-}
-
-func TestRequestSignatureGetWithQuery(t *testing.T) {
-	req := newTestRequest(
-		"GET /foo/bar?baz=quux HTTP/1.1",
-		"Date: 2015-09-29",
-		"Cookie: foo; bar; baz=quux",
-		"Gap-Auth: mbland",
-		"",
-		"",
-	)
-
-	assert.Equal(t, StringToSign(req, HEADERS), strings.Join([]string{
-		"GET",
-		"",
-		"",
-		"",
-		"32015-09-29",
-		"",
-		"",
-		"",
-		"",
-		"8foo; bar; baz=quux",
-		"9mbland",
-		"/foo/bar?baz=quux",
-	}, "\n"))
-	assert.Equal(t, RequestSignature(req, crypto.SHA1, HEADERS, "foobar"),
-		"sha1 vmli4diHuoO8zY6/9aXmA/yli/o=")
 }
 
 func TestRequestSignatureGetWithFullUrl(t *testing.T) {
@@ -158,17 +110,17 @@ func TestRequestSignatureGetWithFullUrl(t *testing.T) {
 		"",
 		"",
 		"",
-		"32015-09-29",
+		"2015-09-29",
 		"",
 		"",
 		"",
 		"",
-		"8foo; bar; baz=quux",
-		"9mbland",
+		"foo; bar; baz=quux",
+		"mbland",
 		"/foo/bar?baz=quux#xyzzy",
 	}, "\n"))
 	assert.Equal(t, RequestSignature(req, crypto.SHA1, HEADERS, "foobar"),
-		"sha1 q5cfavzhqjXieJPAH/fxZHAH3eE=")
+		"sha1 gw1nuRYzkocv5q8nQSo3pT5F970=")
 }
 
 func TestRequestSignatureGetWithMultipleHeadersWithTheSameName(t *testing.T) {
@@ -189,19 +141,17 @@ func TestRequestSignatureGetWithMultipleHeadersWithTheSameName(t *testing.T) {
 		"",
 		"",
 		"",
-		"32015-09-29",
+		"2015-09-29",
 		"",
 		"",
 		"",
 		"",
-		"8foo",
-		"8bar",
-		"8baz=quux",
-		"9mbland",
+		"foo,bar,baz=quux",
+		"mbland",
 		"/foo/bar",
 	}, "\n"))
 	assert.Equal(t, RequestSignature(req, crypto.SHA1, HEADERS, "foobar"),
-		"sha1 cSoEl8xNddC3AiYzPlsFWQg8H3w=")
+		"sha1 VnoxQC+mg2Oils+Cbz1j1c9LXLE=")
 }
 
 func TestValidateRequestNoSignature(t *testing.T) {

--- a/hmacauth_test.go
+++ b/hmacauth_test.go
@@ -81,7 +81,7 @@ func TestRequestSignaturePost(t *testing.T) {
 		"/foo/bar",
 	}, "\n"))
 	assert.Equal(t, RequestSignature(req, crypto.SHA1, HEADERS, "foobar"),
-		"sha1 Z7pb9nRlDgdrWgEG-onLubac-0w=")
+		"sha1 Z7pb9nRlDgdrWgEG+onLubac+0w=")
 }
 
 func newGetRequest() *http.Request {
@@ -112,7 +112,7 @@ func TestRequestSignatureGet(t *testing.T) {
 		"/foo/bar",
 	}, "\n"))
 	assert.Equal(t, RequestSignature(req, crypto.SHA1, HEADERS, "foobar"),
-		"sha1 pehRvdQcu0CxCIN9Ky-a5jasYYw=")
+		"sha1 pehRvdQcu0CxCIN9Ky+a5jasYYw=")
 }
 
 func TestRequestSignatureGetWithQuery(t *testing.T) {
@@ -140,7 +140,7 @@ func TestRequestSignatureGetWithQuery(t *testing.T) {
 		"/foo/bar?baz=quux",
 	}, "\n"))
 	assert.Equal(t, RequestSignature(req, crypto.SHA1, HEADERS, "foobar"),
-		"sha1 vmli4diHuoO8zY6_9aXmA_yli_o=")
+		"sha1 vmli4diHuoO8zY6/9aXmA/yli/o=")
 }
 
 func TestRequestSignatureGetWithFullUrl(t *testing.T) {
@@ -168,7 +168,7 @@ func TestRequestSignatureGetWithFullUrl(t *testing.T) {
 		"/foo/bar?baz=quux#xyzzy",
 	}, "\n"))
 	assert.Equal(t, RequestSignature(req, crypto.SHA1, HEADERS, "foobar"),
-		"sha1 q5cfavzhqjXieJPAH_fxZHAH3eE=")
+		"sha1 q5cfavzhqjXieJPAH/fxZHAH3eE=")
 }
 
 func TestRequestSignatureGetWithMultipleHeadersWithTheSameName(t *testing.T) {

--- a/hmacauth_test.go
+++ b/hmacauth_test.go
@@ -41,6 +41,15 @@ func TestUnsupportedHashAlgorithm(t *testing.T) {
 	assert.Equal(t, algorithm.Available(), false)
 }
 
+func TestUnsupportedAlgorithmWillCauseNewHmacAuthToPanic(t *testing.T) {
+	defer func() {
+		err := recover()
+		assert.Equal(t, err,
+			"hmacauth: hash algorithm #0 is unavailable")
+	}()
+	NewHmacAuth(crypto.Hash(0), nil, "", nil)
+}
+
 func newTestRequest(request ...string) (req *http.Request) {
 	reqBuf := bufio.NewReader(
 		strings.NewReader(strings.Join(request, "\n")))

--- a/hmacauth_test.go
+++ b/hmacauth_test.go
@@ -156,7 +156,8 @@ func TestRequestSignatureGetWithMultipleHeadersWithTheSameName(t *testing.T) {
 
 func TestValidateRequestNoSignature(t *testing.T) {
 	req := newGetRequest()
-	result, header, computed := ValidateRequest(req, HEADERS, "foobar")
+	result, header, computed := ValidateRequest(
+		req, "GAP-Signature", HEADERS, "foobar")
 	assert.Equal(t, result, NO_SIGNATURE)
 	assert.Equal(t, header, "")
 	assert.Equal(t, computed, "")
@@ -166,7 +167,8 @@ func TestValidateRequestInvalidFormat(t *testing.T) {
 	req := newGetRequest()
 	badValue := "should be algorithm and digest value"
 	req.Header.Set("GAP-Signature", badValue)
-	result, header, computed := ValidateRequest(req, HEADERS, "foobar")
+	result, header, computed := ValidateRequest(
+		req, "GAP-Signature", HEADERS, "foobar")
 	assert.Equal(t, result, INVALID_FORMAT)
 	assert.Equal(t, header, badValue)
 	assert.Equal(t, computed, "")
@@ -178,7 +180,8 @@ func TestValidateRequestUnsupportedAlgorithm(t *testing.T) {
 	components := strings.Split(validSignature, " ")
 	signatureWithUnsupportedAlgorithm := "unsupported " + components[1]
 	req.Header.Set("GAP-Signature", signatureWithUnsupportedAlgorithm)
-	result, header, computed := ValidateRequest(req, HEADERS, "foobar")
+	result, header, computed := ValidateRequest(
+		req, "GAP-Signature", HEADERS, "foobar")
 	assert.Equal(t, result, UNSUPPORTED_ALGORITHM)
 	assert.Equal(t, header, signatureWithUnsupportedAlgorithm)
 	assert.Equal(t, computed, "")
@@ -188,7 +191,8 @@ func TestValidateRequestMatch(t *testing.T) {
 	req := newGetRequest()
 	expected := RequestSignature(req, crypto.SHA1, HEADERS, "foobar")
 	req.Header.Set("GAP-Signature", expected)
-	result, header, computed := ValidateRequest(req, HEADERS, "foobar")
+	result, header, computed := ValidateRequest(
+		req, "GAP-Signature", HEADERS, "foobar")
 	assert.Equal(t, result, MATCH)
 	assert.Equal(t, header, expected)
 	assert.Equal(t, computed, expected)
@@ -199,7 +203,8 @@ func TestValidateRequestMismatch(t *testing.T) {
 	foobarSignature := RequestSignature(req, crypto.SHA1, HEADERS, "foobar")
 	barbazSignature := RequestSignature(req, crypto.SHA1, HEADERS, "barbaz")
 	req.Header.Set("GAP-Signature", foobarSignature)
-	result, header, computed := ValidateRequest(req, HEADERS, "barbaz")
+	result, header, computed := ValidateRequest(
+		req, "GAP-Signature", HEADERS, "barbaz")
 	assert.Equal(t, result, MISMATCH)
 	assert.Equal(t, header, foobarSignature)
 	assert.Equal(t, computed, barbazSignature)

--- a/hmacauth_test.go
+++ b/hmacauth_test.go
@@ -200,7 +200,7 @@ func TestValidateRequestMatch(t *testing.T) {
 	h := testHmacAuth()
 	req := newGetRequest()
 	expected := h.RequestSignature(req)
-	req.Header.Set("GAP-Signature", expected)
+	h.SignRequest(req)
 	result, header, computed := h.ValidateRequest(req)
 	assert.Equal(t, result, MATCH)
 	assert.Equal(t, header, expected)
@@ -212,11 +212,9 @@ func TestValidateRequestMismatch(t *testing.T) {
 	barbazAuth := NewHmacAuth(
 		crypto.SHA1, []byte("barbaz"), "GAP-Signature", HEADERS)
 	req := newGetRequest()
-	foobarSignature := foobarAuth.RequestSignature(req)
-	barbazSignature := barbazAuth.RequestSignature(req)
-	req.Header.Set("GAP-Signature", foobarSignature)
+	foobarAuth.SignRequest(req)
 	result, header, computed := barbazAuth.ValidateRequest(req)
 	assert.Equal(t, result, MISMATCH)
-	assert.Equal(t, header, foobarSignature)
-	assert.Equal(t, computed, barbazSignature)
+	assert.Equal(t, header, foobarAuth.RequestSignature(req))
+	assert.Equal(t, computed, barbazAuth.RequestSignature(req))
 }

--- a/hmacauth_test.go
+++ b/hmacauth_test.go
@@ -68,20 +68,20 @@ func TestRequestSignaturePost(t *testing.T) {
 	)
 	assert.Equal(t, StringToSign(req, HEADERS), strings.Join([]string{
 		"POST",
-		strconv.Itoa(len(body)),
-		"deadbeef",
-		"application/json",
-		"2015-09-28",
-		"trust me",
-		"mbland",
-		"mbland@acm.org",
-		"feedbead",
-		"foo; bar; baz=quux",
-		"mbland",
+		"0" + strconv.Itoa(len(body)),
+		"1deadbeef",
+		"2application/json",
+		"32015-09-28",
+		"4trust me",
+		"5mbland",
+		"6mbland@acm.org",
+		"7feedbead",
+		"8foo; bar; baz=quux",
+		"9mbland",
 		"/foo/bar",
 	}, "\n"))
 	assert.Equal(t, RequestSignature(req, crypto.SHA1, HEADERS, "foobar"),
-		"sha1 722UbRYfC6MnjtIxqEJMDPrW2mk=")
+		"sha1 Z7pb9nRlDgdrWgEG-onLubac-0w=")
 }
 
 func newGetRequest() *http.Request {
@@ -102,17 +102,17 @@ func TestRequestSignatureGet(t *testing.T) {
 		"",
 		"",
 		"",
-		"2015-09-29",
+		"32015-09-29",
 		"",
 		"",
 		"",
 		"",
-		"foo; bar; baz=quux",
-		"mbland",
+		"8foo; bar; baz=quux",
+		"9mbland",
 		"/foo/bar",
 	}, "\n"))
 	assert.Equal(t, RequestSignature(req, crypto.SHA1, HEADERS, "foobar"),
-		"sha1 JBQJcmSTteQyHZXFUA9glis9BIk=")
+		"sha1 pehRvdQcu0CxCIN9Ky-a5jasYYw=")
 }
 
 func TestRequestSignatureGetWithQuery(t *testing.T) {
@@ -130,17 +130,17 @@ func TestRequestSignatureGetWithQuery(t *testing.T) {
 		"",
 		"",
 		"",
-		"2015-09-29",
+		"32015-09-29",
 		"",
 		"",
 		"",
 		"",
-		"foo; bar; baz=quux",
-		"mbland",
+		"8foo; bar; baz=quux",
+		"9mbland",
 		"/foo/bar?baz=quux",
 	}, "\n"))
 	assert.Equal(t, RequestSignature(req, crypto.SHA1, HEADERS, "foobar"),
-		"sha1 IdVTzG_70lbqE52JoYHmR2oDYO8=")
+		"sha1 vmli4diHuoO8zY6_9aXmA_yli_o=")
 }
 
 func TestRequestSignatureGetWithMultipleHeadersWithTheSameName(t *testing.T) {
@@ -161,19 +161,19 @@ func TestRequestSignatureGetWithMultipleHeadersWithTheSameName(t *testing.T) {
 		"",
 		"",
 		"",
-		"2015-09-29",
+		"32015-09-29",
 		"",
 		"",
 		"",
 		"",
-		"foo",
-		"bar",
-		"baz=quux",
-		"mbland",
+		"8foo",
+		"8bar",
+		"8baz=quux",
+		"9mbland",
 		"/foo/bar",
 	}, "\n"))
 	assert.Equal(t, RequestSignature(req, crypto.SHA1, HEADERS, "foobar"),
-		"sha1 3QTHq0aEEwZz637DtDXoT48afrc=")
+		"sha1 cSoEl8xNddC3AiYzPlsFWQg8H3w=")
 }
 
 func TestValidateRequestNoSignature(t *testing.T) {

--- a/hmacauth_test.go
+++ b/hmacauth_test.go
@@ -97,9 +97,9 @@ func TestRequestSignaturePost(t *testing.T) {
 		"foo; bar; baz=quux",
 		"mbland",
 		"/foo/bar",
-	}, "\n"))
+	}, "\n")+"\n")
 	assert.Equal(t, h.RequestSignature(req),
-		"sha1 722UbRYfC6MnjtIxqEJMDPrW2mk=")
+		"sha1 K4IrVDtMCRwwW8Oms0VyZWMjXHI=")
 }
 
 func newGetRequest() *http.Request {
@@ -115,7 +115,7 @@ func newGetRequest() *http.Request {
 
 func TestRequestSignatureGetWithFullUrl(t *testing.T) {
 	req := newTestRequest(
-		"GET http://localhost/foo/bar?baz=quux#xyzzy HTTP/1.1",
+		"GET http://localhost/foo/bar?baz=quux%2Fxyzzy#plugh HTTP/1.1",
 		"Date: 2015-09-29",
 		"Cookie: foo; bar; baz=quux",
 		"Gap-Auth: mbland",
@@ -136,10 +136,10 @@ func TestRequestSignatureGetWithFullUrl(t *testing.T) {
 		"",
 		"foo; bar; baz=quux",
 		"mbland",
-		"/foo/bar?baz=quux#xyzzy",
-	}, "\n"))
+		"/foo/bar?baz=quux%2Fxyzzy#plugh",
+	}, "\n")+"\n")
 	assert.Equal(t, h.RequestSignature(req),
-		"sha1 gw1nuRYzkocv5q8nQSo3pT5F970=")
+		"sha1 ih5Jce9nsltry63rR4ImNz2hdnk=")
 }
 
 func TestRequestSignatureGetWithMultipleHeadersWithTheSameName(t *testing.T) {
@@ -169,9 +169,9 @@ func TestRequestSignatureGetWithMultipleHeadersWithTheSameName(t *testing.T) {
 		"foo,bar,baz=quux",
 		"mbland",
 		"/foo/bar",
-	}, "\n"))
+	}, "\n")+"\n")
 	assert.Equal(t, h.RequestSignature(req),
-		"sha1 VnoxQC+mg2Oils+Cbz1j1c9LXLE=")
+		"sha1 JlRkes1X+qq3Bgc/GcRyLos+4aI=")
 }
 
 func TestValidateRequestNoSignature(t *testing.T) {

--- a/hmacauth_test.go
+++ b/hmacauth_test.go
@@ -1,8 +1,9 @@
-package hmacauth
+package hmacauth_test
 
 import (
 	"bufio"
 	"crypto"
+	. "github.com/18F/hmacauth"
 	"net/http"
 	"strconv"
 	"strings"
@@ -60,7 +61,7 @@ func newTestRequest(request ...string) (req *http.Request) {
 	}
 }
 
-func testHmacAuth() *HmacAuth {
+func testHmacAuth() HmacAuth {
 	return NewHmacAuth(
 		crypto.SHA1, []byte("foobar"), "GAP-Signature", HEADERS)
 }


### PR DESCRIPTION
Per @jehiah's suggestion in bitly/oauth2_proxy#147.

Also ensures that the path, query, and fragment of the URL is factored in.

@jehiah, to your other points from bitly/oauth2_proxy#147 (and I'd like to hear others weigh in as well):

I've tried using an integer index instead of the full header name to distinguish header values that correspond to the same header. How does that sound as an alternative to including the full header name?

Not sure if enforcing that the header fields are processed in sorted order is useful at this level of abstraction. The application could certainly enforce this policy, though. Thoughts?

cc: @jcscottiii as my primary Go reviewer.

cc: @dhcole, @jmcarp and @ozzyjohnson for the general approach. I'll port whatever happens in this PR to https://rubygems.org/gems/hmac_authentication and https://www.npmjs.com/package/hmac-authentication, and I'll also get a Python module started shortly.
