### PR TITLE
s/Validate/Authenticate/g

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.log
 .*.swp
+coverage.out

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Coverage Status](https://coveralls.io/repos/18F/hmacauth/badge.svg?branch=master&service=github)](https://coveralls.io/github/18F/hmacauth?branch=master)
 
-Signs and validates HTTP requests based on a shared-secret HMAC signature.
+Signs and authenticates HTTP requests based on a shared-secret HMAC signature.
 
 Developed in parallel with the following packages for other languages:
 - Node.js: [hmac-authentication](https://www.npmjs.com/package/hmac-authentication)

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -28,7 +28,7 @@ type HmacAuth interface {
 
 	// Authenticates the request, returning the result code, the signature
 	// from the header, and the locally-computed signature.
-	ValidateRequest(request *http.Request) (
+	AuthenticateRequest(request *http.Request) (
 		result ValidationResult,
 		headerSignature, computedSignature string)
 }
@@ -169,7 +169,7 @@ func (auth *hmacAuth) SignatureFromHeader(req *http.Request) string {
 }
 
 // ValidationResult is a code used to identify the outcome of
-// HmacAuth.ValidateRequest().
+// HmacAuth.AuthenticateRequest().
 type ValidationResult int
 
 const (
@@ -206,7 +206,7 @@ func (result ValidationResult) String() string {
 	return validationResultStrings[result]
 }
 
-func (auth *hmacAuth) ValidateRequest(request *http.Request) (
+func (auth *hmacAuth) AuthenticateRequest(request *http.Request) (
 	result ValidationResult, headerSignature, computedSignature string) {
 	headerSignature = auth.SignatureFromHeader(request)
 	if headerSignature == "" {

--- a/hmacauth_test.go
+++ b/hmacauth_test.go
@@ -174,27 +174,27 @@ func TestRequestSignatureGetWithMultipleHeadersWithTheSameName(t *testing.T) {
 		"sha1 JlRkes1X+qq3Bgc/GcRyLos+4aI=")
 }
 
-func TestValidateRequestResultNoSignature(t *testing.T) {
+func TestAuthenticateRequestResultNoSignature(t *testing.T) {
 	h := testHmacAuth()
 	req := newGetRequest()
-	result, header, computed := h.ValidateRequest(req)
+	result, header, computed := h.AuthenticateRequest(req)
 	assert.Equal(t, result, ResultNoSignature)
 	assert.Equal(t, header, "")
 	assert.Equal(t, computed, "")
 }
 
-func TestValidateRequestResultInvalidFormat(t *testing.T) {
+func TestAuthenticateRequestResultInvalidFormat(t *testing.T) {
 	h := testHmacAuth()
 	req := newGetRequest()
 	badValue := "should be algorithm and digest value"
 	req.Header.Set("GAP-Signature", badValue)
-	result, header, computed := h.ValidateRequest(req)
+	result, header, computed := h.AuthenticateRequest(req)
 	assert.Equal(t, result, ResultInvalidFormat)
 	assert.Equal(t, header, badValue)
 	assert.Equal(t, computed, "")
 }
 
-func TestValidateRequestResultUnsupportedAlgorithm(t *testing.T) {
+func TestAuthenticateRequestResultUnsupportedAlgorithm(t *testing.T) {
 	h := testHmacAuth()
 	req := newGetRequest()
 	validSignature := h.RequestSignature(req)
@@ -202,30 +202,30 @@ func TestValidateRequestResultUnsupportedAlgorithm(t *testing.T) {
 	signatureWithResultUnsupportedAlgorithm := "unsupported " +
 		components[1]
 	req.Header.Set("GAP-Signature", signatureWithResultUnsupportedAlgorithm)
-	result, header, computed := h.ValidateRequest(req)
+	result, header, computed := h.AuthenticateRequest(req)
 	assert.Equal(t, result, ResultUnsupportedAlgorithm)
 	assert.Equal(t, header, signatureWithResultUnsupportedAlgorithm)
 	assert.Equal(t, computed, "")
 }
 
-func TestValidateRequestResultMatch(t *testing.T) {
+func TestAuthenticateRequestResultMatch(t *testing.T) {
 	h := testHmacAuth()
 	req := newGetRequest()
 	expected := h.RequestSignature(req)
 	h.SignRequest(req)
-	result, header, computed := h.ValidateRequest(req)
+	result, header, computed := h.AuthenticateRequest(req)
 	assert.Equal(t, result, ResultMatch)
 	assert.Equal(t, header, expected)
 	assert.Equal(t, computed, expected)
 }
 
-func TestValidateRequestMismatch(t *testing.T) {
+func TestAuthenticateRequestMismatch(t *testing.T) {
 	foobarAuth := testHmacAuth()
 	barbazAuth := NewHmacAuth(
 		crypto.SHA1, []byte("barbaz"), "GAP-Signature", HEADERS)
 	req := newGetRequest()
 	foobarAuth.SignRequest(req)
-	result, header, computed := barbazAuth.ValidateRequest(req)
+	result, header, computed := barbazAuth.AuthenticateRequest(req)
 	assert.Equal(t, result, ResultMismatch)
 	assert.Equal(t, header, foobarAuth.RequestSignature(req))
 	assert.Equal(t, computed, barbazAuth.RequestSignature(req))


### PR DESCRIPTION
Also thinking of bumping the version tag to 1.0.0 after this, as the interface seems stable across this, 18F/hmac-authentication-npm, 18F/hmac_authentication_gem, and 18F/hmac_authentication_py.

cc: @jcscottiii 
