### PR TITLE
Ensure the request body buffer is not exhausted

### DIFF
--- a/hmacauth.go
+++ b/hmacauth.go
@@ -6,6 +6,7 @@ import (
 	"crypto/hmac"
 	"encoding/base64"
 	"errors"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -153,9 +154,9 @@ func requestSignature(auth *hmacAuth, req *http.Request,
 	_, _ = h.Write([]byte(auth.StringToSign(req)))
 
 	if req.ContentLength != -1 && req.Body != nil {
-		buf := make([]byte, req.ContentLength, req.ContentLength)
-		_, _ = req.Body.Read(buf)
-		_, _ = h.Write(buf)
+		reqBody, _ := ioutil.ReadAll(req.Body)
+		req.Body = ioutil.NopCloser(bytes.NewBuffer(reqBody))
+		_, _ = h.Write(reqBody)
 	}
 
 	var sig []byte

--- a/hmacauth_test.go
+++ b/hmacauth_test.go
@@ -3,6 +3,7 @@ package hmacauth
 import (
 	"bufio"
 	"crypto"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -100,6 +101,12 @@ func TestRequestSignaturePost(t *testing.T) {
 	}, "\n")+"\n")
 	assert.Equal(t, h.RequestSignature(req),
 		"sha1 K4IrVDtMCRwwW8Oms0VyZWMjXHI=")
+
+	if requestBody, err := ioutil.ReadAll(req.Body); err != nil {
+		panic(err)
+	} else {
+		assert.Equal(t, string(requestBody), body)
+	}
 }
 
 func newGetRequest() *http.Request {


### PR DESCRIPTION
Was notified of the issue when @dlapiduz pinged me about POST requests
to https://tock.18f.gov/ resulting in 500s. Digging in the oauth2_proxy logs,
I noticed messages like this appearing before every 500:

```
2015/10/09 16:08:15 reverseproxy.go:184: http: proxy error: http: ContentLength=128 with Body length 0
```

Searching for that error string turned up:

https://stackoverflow.com/questions/23070876/reading-body-of-http-request-without-modifying-request-state

The issue was that reading from `http.Request.Body` to generate the request
signature was exhausting the `io.ReadCloser`. The solution was to read the
entire body into a new buffer, wrap that buffer in an `ioutil.NopCloser` and
assign it back to `http.Request.Body`, and then use that same buffer to
compute the signature.

The new assert statement in `TestRequestSignaturePost` reproduced the original
bug and verified the fix.

cc: @jcscottiii 
