### PR TITLE
Eliminate content length check in requestSignature

### DIFF
--- a/hmacauth.go
+++ b/hmacauth.go
@@ -153,7 +153,7 @@ func requestSignature(auth *hmacAuth, req *http.Request,
 	h := hmac.New(hashAlgorithm.New, auth.key)
 	_, _ = h.Write([]byte(auth.StringToSign(req)))
 
-	if req.ContentLength != -1 && req.Body != nil {
+	if req.Body != nil {
 		reqBody, _ := ioutil.ReadAll(req.Body)
 		req.Body = ioutil.NopCloser(bytes.NewBuffer(reqBody))
 		_, _ = h.Write(reqBody)

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -30,7 +30,7 @@ type HmacAuth interface {
 	// Authenticates the request, returning the result code, the signature
 	// from the header, and the locally-computed signature.
 	AuthenticateRequest(request *http.Request) (
-		result ValidationResult,
+		result AuthenticationResult,
 		headerSignature, computedSignature string)
 }
 
@@ -169,14 +169,14 @@ func (auth *hmacAuth) SignatureFromHeader(req *http.Request) string {
 	return req.Header.Get(auth.header)
 }
 
-// ValidationResult is a code used to identify the outcome of
+// AuthenticationResult is a code used to identify the outcome of
 // HmacAuth.AuthenticateRequest().
-type ValidationResult int
+type AuthenticationResult int
 
 const (
 	// ResultNoSignature - the incoming result did not have a signature
 	// header.
-	ResultNoSignature ValidationResult = iota
+	ResultNoSignature AuthenticationResult = iota
 
 	// ResultInvalidFormat - the signature header was not parseable.
 	ResultInvalidFormat
@@ -203,12 +203,13 @@ var validationResultStrings = []string{
 	"ResultMismatch",
 }
 
-func (result ValidationResult) String() string {
+func (result AuthenticationResult) String() string {
 	return validationResultStrings[result]
 }
 
 func (auth *hmacAuth) AuthenticateRequest(request *http.Request) (
-	result ValidationResult, headerSignature, computedSignature string) {
+	result AuthenticationResult, headerSignature,
+	computedSignature string) {
 	headerSignature = auth.SignatureFromHeader(request)
 	if headerSignature == "" {
 		result = ResultNoSignature


### PR DESCRIPTION
Turns out the content length may not be defined for all POST requests, and may
be 0 on the sending end and -1 on the receiving end, leading to signature
mismatches. The new `TestSendAuthenticatedPostRequestToServer` reproduces the
bug and validates its fix.

cc: @jcscottiii 
